### PR TITLE
Update to mutant-0.11.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ gem 'test_bench'
 gem 'test_bench-detect_coverage'
 gem 'rspec'
 gem 'minitest'
-gem 'mutant'
-gem 'mutant-minitest'
-gem 'mutant-rspec'
+gem 'mutant',          '~> 0.11.15'
+gem 'mutant-minitest', '~> 0.11.15'
+gem 'mutant-rspec',    '~> 0.11.15'
 
 source 'https://oss:b1fGXjjsKhbxQPnWRXeRDYpW5xpzgUYy@gem.mutant.dev' do
   gem 'mutant-license'


### PR DESCRIPTION
* This release provides a more correct Mutant::Config::DEFAULT
  constant that sets the coverage criteria that where previously missing
* In mutants CLI usage, these coverage criteria would be set during CLI
  parsing, but where not by default populated in API mode.